### PR TITLE
Fix markdown emphasis

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -59,5 +59,5 @@ If you are interested in the bits and bytes of PIV credentials, you can review t
 To review the Standards, there is a [NIST website](http://csrc.nist.gov/groups/SNS/piv/standards.html){:target="_blank"} with all PIV related Standards.  Links to some of the most common Standards:
 
 - **[FIPS-201](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.201-2.pdf){:target="_blank"}** specifies the issuance and management of PIV credentials.
-- **[NIST Special Publication 800-73, "Interfaces for Personal Identity Verification"](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf){:target="_blank"} ** specifies the interface and data elements of PIV credentials.
-- **[NIST Special Publication 800-76, "Biometric Data Specification for Personal Identity Verification"](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-76-2.pdf){:target="_blank"} ** specifies the technical acquisition and formatting requirements for biometric data of PIV credentials.
+- **[NIST Special Publication 800-73, "Interfaces for Personal Identity Verification"](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf){:target="_blank"}** specifies the interface and data elements of PIV credentials.
+- **[NIST Special Publication 800-76, "Biometric Data Specification for Personal Identity Verification"](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-76-2.pdf){:target="_blank"}** specifies the technical acquisition and formatting requirements for biometric data of PIV credentials.


### PR DESCRIPTION
The asterisks had a space in them that was causing them to show up. This is how it looks now:

![screenshot from 2017-03-27 10-00-24](https://cloud.githubusercontent.com/assets/4592/24360068/42a4201a-12d4-11e7-812c-4838c08facbc.png)

That said, it looks like `<strong>` tags don't actually cause bolding or other emphasis on the site. That I didn't touch. 