### PR TITLE
Add 3rem margin-bttom to Alert box

### DIFF
--- a/assets/css/styleguide.css
+++ b/assets/css/styleguide.css
@@ -1766,6 +1766,7 @@ p a,
   background-repeat: no-repeat;
   background-size: 4rem;
   margin-top: 1.5em;
+  margin-bottom: 3rem
   padding: 1em; }
   @media screen and (min-width: 600px) {
     .usa-alert {


### PR DESCRIPTION
The issue was there is no space between bottom of alert box and following content, looking crammed in rendering. The solution is to add 3 rem margin-bottom to class usa-alert. The change will impact all md documents that have Alert box; We need to watch for regression in existing document rendering.