### PR TITLE
Revert "Remove title of index.md from sidebar, fixing issue #147"

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -16,11 +16,9 @@
           <ul class="nav-children usa-current-section" id="nav-collapsible-{{ forloop.index }}" aria-hidden="{% if page.collection == link.collname %}false{% else %}true{% endif %}">
       
           {% for child in site.[collectionName] %}
-              {% if child.url != page.url %}
-              <li class="group {% if page.title == child.title %}usa-current{% endif %}">
-                <a href="{{ site.baseurl }}{{ child.url }}" title="{% if page.title == child.title %}Current Page {% else %}{{ child.title }}{% endif %}">{{ child.title}}</a>
-              </li>
-              {% endif %}
+          <li class="group {% if page.title == child.title %}usa-current{% endif %}">
+          <a href="{{ site.baseurl }}{{ child.url }}" title="{% if page.title == child.title %}Current Page {% else %}{{ child.title }}{% endif %}">{{ child.title }}</a>
+          </li>
           {% endfor %}
           </ul>
           {% endif %}


### PR DESCRIPTION
Reverts GSA/piv-guides#151

@godadada 
I merged your PR first.  I am working on sync'ing the PRs, minor testing, and resolving conflicts. 

**I'm reverting this pull request and change.**  

Problem: 
- the sidebar if/then statements in #151 takes an input of the _current page url_, and then removes the child page from the navigation if there is a match. 
- **Actual outcome**: user is on the: /networkconfig/domaincontrollers/ page, and the Domain Controllers page doesn't show up in the navigation.
- **Expected outcome**: the duplicate listing of the top level navigation (/networkconfig/) as a duplicate child page is hidden at all times.   can look at page.collection or link.collname instead to do a check?   