### PR TITLE
Fixing a typo in the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,7 +14,7 @@
 	<p>Have an idea? Read our <a href="{{ site.repo_url }}/blob/{{ site.branch }}/CONTRIBUTING.md">contribution guidelines</a>.</p>
   </div>
   <div class="usa-width-one-fourth last-child">
-    <p>As a work of the United States government, this project is in the public domain. Copyright is also waved internationally via a CC0 1.0 waiver. </p>
+    <p>As a work of the United States government, this project is in the public domain. Copyright is also waived internationally via a CC0 1.0 waiver. </p>
     <p><a href="{{ site.repo_url }}/blob/{{ site.branch }}/LICENSE.md">Read More.</a></p>
   </div>
   <div class="usa-width-one-fourth">


### PR DESCRIPTION
With apologies for the lamest pull request ever... "waved" should be "waived" in the footer