### PR TITLE
204 firefox update

### DIFF
--- a/_engineering/01_firefox.md
+++ b/_engineering/01_firefox.md
@@ -5,27 +5,26 @@ collection: engineering
 permalink: engineering/firefox/
 ---
 
-You may need to configure Firefox so your agency users can log into web applications using their PIV credentials.<!--"Configure agency users" doesn't make sense-->This can be tricky because Firefox supports a protocol (PKCS #11) that is not always natively supported by operating systems or their default drivers.  
+You may need to configure Firefox to enable your agency users to log into web applications using their PIV credentials. This can be tricky because Firefox supports a protocol (PKCS #11) that is not always natively supported by operating systems or OS default drivers. 
 
-This guide will help you configure Firefox for your users by using an open source software package.  In addition to open source solutions, commercial software may be used. 
+This guide will help you to configure Firefox by using an open source software package.  In addition to open source solutions, commercial software may be used. 
 
 * [Install and Test OpenSC](#install-and-test-opensc)
 * [Configure Firefox](#configure-firefox)
 
 {% include alert-info.html heading="PKCS #11" content="You are interested in learning more? Search for PKCS #11 for other resources available." %} 
 
-
 ## Install and Test OpenSC
-OpenSC will enable a PIV credential to work with Firefox and some signing and encryption applications.  
+OpenSC will enable a user's PIV credential to work with Firefox and some signing and encryption applications.
 
-First, you will need to install and test **OpenSC**. OpenSC has installers for multiple operating systems, including Windows, macOS, and Linux flavors. The installers can be downloaded directly from GitHub and the OpenSC wiki.<!--Are "installers" = modules?-->
+First, you will need to install and test **OpenSC**. OpenSC has installers for multiple operating systems, including Windows, macOS, and Linux flavors. The installers can be downloaded directly from GitHub and the OpenSC wiki:
 
 * [View instructions and installation procedures for OpenSC](https://github.com/OpenSC/OpenSC/wiki/){:target="_blank"}
 
-When downloading and installing OpenSC, you need to consider some items that are specific for the U.S. Government: 
+When installing OpenSC, you need to consider some items that are specific for the U.S. Government: 
 
-* Even if the computer is running a 64-bit OS, you will need to download and install _both the 64- and 32-bit versions_ of OpenSC.
-* You do not need to install the full packages for OpenSC.<!--Meaning -- Light-Release? Do we recommend one in particular?-->
+* You will need to download and install either the 64-bit or 32-bit version of OpenSC, depending on the OS.
+* You do not need to install the full packages for OpenSC.<!--No need to be more specific?-->
 * You can limit the packages for distribution to enterprise workstations to just support PKCS #11.
 * You can push the packages to the enterprise workstations using your enterprise configuration management tools.
 
@@ -33,27 +32,28 @@ When downloading and installing OpenSC, you need to consider some items that are
 
 ### Load New Security Device
 
-Launch **_Firefox_** and load a new _Security Device_ using the OpenSC PKCS #11 driver:
+Launch **_Firefox_** and load a new _Security Device_ (i.e., the Security Device is your PIV credential) using the OpenSC PKCS #11 driver:
 * From the _Firefox_ taskbar, click the _Options_ icon ("gear" shape). 
 * Click the _Privacy & Security_ menu from the left-hand navigation.
 * Scroll down until you see the _Certificates_ heading, and then click _Security Devices_.
-* At the _Device Manager_ window, click the _Load_ button and enter the module name: _OpenSC PKCS#11 Module_.<!--Where is the module name listed in OpenSC downloads? Is the module the same thing as the driver? (We seem to use "driver" in other places)? Don't see that name in OpenSC download list. No space before "#11"?-->
-* Select the location of the OpenSC PKCS #11 driver based on OS. The default locations include:
+* At the _Device Manager_ window, click the _Load_ button and enter this module name: _OpenSC PKCS#11 Module_.
+* Select the directory where the OpenSC PKCS #11 driver is located. The default locations are:
 
 | **OS** | **Default Driver Location** | **Driver File Name** | 
 | ----- | -------| -------| 
-| _Windows_ | C:\Windows\System32 | pkcs11.dll | 
-| _macOS_  | /Library/OpenSC/lib/ | pkcs11.so | 
-| _Linux_  | /usr/lib/ | pkcs11.so | 
+| **Windows** | C:\Windows\System32 | pkcs11.dll | 
+| **macOS**  | /Library/OpenSC/lib/ | pkcs11.so | 
+| **Linux**  | /usr/lib/ | pkcs11.so | 
 
-* Click _Open_ and verify that the module has been loaded<!--installed?-->. Then, click _OK_ to return to the _Privacy & Security_ options.
+* Click _Open_ and verify that the module has been loaded. Then, click _OK_ to return to the _Privacy & Security_ options.
 
 ### Import PIV Issuer Certificate
 * Click the _View Certificates_ button. If prompted, enter your PIV credential PIN.
 * Click the _Authorities_ tab from the top navigation.
-* Click the _Import_ button to import a copy of your PIV credential issuer's certification authority certificate. When prompted, trust the certificate for _both_ identifying websites and email users.
+* Click the _Import_ button to import a copy of your PIV credential issuer's Certification Authority (CA) certificate. When prompted, trust the certificate for identifying websites _and_ email users_.
 * Click _OK_ and restart _Firefox_.
 
-### Restart and Test Authentication
-* Browse to a web application that requires a PIV to authenticate.  A common web application to use is **Max.gov**.
+### Restart Firefox and Test Authentication
+* Restart Firefox. 
+* Browse to a web application that requires authentication with a PIV credential.  A common web application to use as a test is [MAX.gov](https://max.gov/maxportal/home.action){:target="_blank"}. (**Note:** You'll need to have an existing MAX.gov account for this to work.)
 * Firefox will prompt you to enter your PIV credential PIN and select a certificate for authentication.

--- a/_engineering/01_firefox.md
+++ b/_engineering/01_firefox.md
@@ -50,7 +50,7 @@ Launch **_Firefox_** and load a new _Security Device_ (i.e., the Security Device
 ### Import PIV Issuer Certificate
 * Click the _View Certificates_ button. If prompted, enter your PIV credential PIN.
 * Click the _Authorities_ tab from the top navigation.
-* Click the _Import_ button to import a copy of your PIV credential issuer's Certification Authority (CA) certificate. When prompted, trust the certificate for identifying websites _and_ email users_.
+* Click the _Import_ button to import a copy of your PIV credential issuer's Certification Authority (CA) certificate. When prompted, trust the certificate for identifying websites _and_ email users.
 * Click _OK_ and restart _Firefox_.
 
 ### Restart Firefox and Test Authentication

--- a/_engineering/01_firefox.md
+++ b/_engineering/01_firefox.md
@@ -39,7 +39,7 @@ Launch **_Firefox_** and load a new security device using the OpenSC PKCS #11 dr
 * From the _Firefox_ taskbar, click the _Options_ icon ("gear" shape). 
 * Click the _Privacy & Security_ menu from the left-hand navigation.
 * Scroll down until you see the _Certificates_ heading, then click _Security Devices_.
-* At the _Device Manager_ window, click the _Load_ button and enter the certificate name: _OpenSC PKCS#11 Module_.
+* At the _Device Manager_ window, click the _Load_ button and enter the module name: _OpenSC PKCS#11 Module_.
 * Based on the OS, select the location of the pkcs11 driver.  The default locations include:
 
 | OS | Default driver location | File name | 
@@ -53,7 +53,7 @@ Launch **_Firefox_** and load a new security device using the OpenSC PKCS #11 dr
 ### Import PIV Issuer Certificate
 * Click the _View Certificates_ button. If prompted, enter your PIV credential PIN.
 * Click the _Authorities_ tab from the top navigation.
-* Click the _Import_ button to import a copy of your PIV credential issuer's certification authority certificate. Trust the certificate for _both_ identifying websites and email users.
+* Click the _Import_ button to import a copy of your PIV credential issuer's certification authority certificate. When prompted, trust the certificate for _both_ identifying websites and email users.
 * Click _OK_ and restart _Firefox_.
 
 ### Restart and Test Authentication

--- a/_engineering/01_firefox.md
+++ b/_engineering/01_firefox.md
@@ -5,50 +5,48 @@ collection: engineering
 permalink: engineering/firefox/
 ---
 
-You may need to configure your agency users to use their PIV credentials with Firefox to log into web applications. This can be tricky because Firefox supports a protocol (PKCS #11) that is not always natively supported by operating systems or the default drivers on operating systems.  
+You may need to configure Firefox so your agency users can log into web applications using their PIV credentials.<!--"Configure agency users" doesn't make sense-->This can be tricky because Firefox supports a protocol (PKCS #11) that is not always natively supported by operating systems or their default drivers.  
 
-This guide will help you configure Firefox for your users using an open source software package.  In addition to open source solutions, commercial software may be used. 
+This guide will help you configure Firefox for your users by using an open source software package.  In addition to open source solutions, commercial software may be used. 
 
-* [Install Open Smart Card (OpenSC)](#install-and-test-opensc)
+* [Install and Test OpenSC](#install-and-test-opensc)
 * [Configure Firefox](#configure-firefox)
 
 {% include alert-info.html heading="PKCS #11" content="You are interested in learning more? Search for PKCS #11 for other resources available." %} 
 
 
 ## Install and Test OpenSC
-First, you will need to install and test **OpenSC**. OpenSC will enable a PIV credential to work with the Firefox browser and some signing and encryption applications.  
+OpenSC will enable a PIV credential to work with Firefox and some signing and encryption applications.  
 
-OpenSC has installers for multiple operating systems including Windows, MacOS, and Linux flavors.  
+First, you will need to install and test **OpenSC**. OpenSC has installers for multiple operating systems, including Windows, macOS, and Linux flavors. The installers can be downloaded directly from GitHub and the OpenSC wiki.<!--Are "installers" = modules?-->
 
-* The installers and instructions can be downloaded directly from GitHub and the OpenSC wiki.
-* [View instructions and installation procedures for OpenSC](https://github.com/OpenSC/OpenSC/wiki){:target="_blank"}
+* [View instructions and installation procedures for OpenSC](https://github.com/OpenSC/OpenSC/wiki/){:target="_blank"}
 
-You need to consider some items that are specific for the US Government. 
+When downloading and installing OpenSC, you need to consider some items that are specific for the U.S. Government: 
 
-* Even if the computer is running a 64-bit OS, you will need to download _both the 64- and 32-bit versions_ of OpenSC.
-* You do not need to install the full packages for OpenSC.  
-* You can limit the packages to distribute to your enterprise workstations to just support PKCS#11.  
+* Even if the computer is running a 64-bit OS, you will need to download and install _both the 64- and 32-bit versions_ of OpenSC.
+* You do not need to install the full packages for OpenSC.<!--Meaning -- Light-Release? Do we recommend one in particular?-->
+* You can limit the packages for distribution to enterprise workstations to just support PKCS #11.
 * You can push the packages to the enterprise workstations using your enterprise configuration management tools.
 
 ## Configure Firefox
-Perform the steps below to configure Firefox to enable PIV authentication.
 
 ### Load New Security Device
 
-Launch **_Firefox_** and load a new security device using the OpenSC PKCS #11 driver:
+Launch **_Firefox_** and load a new _Security Device_ using the OpenSC PKCS #11 driver:
 * From the _Firefox_ taskbar, click the _Options_ icon ("gear" shape). 
 * Click the _Privacy & Security_ menu from the left-hand navigation.
-* Scroll down until you see the _Certificates_ heading, then click _Security Devices_.
-* At the _Device Manager_ window, click the _Load_ button and enter the module name: _OpenSC PKCS#11 Module_.
-* Based on the OS, select the location of the pkcs11 driver.  The default locations include:
+* Scroll down until you see the _Certificates_ heading, and then click _Security Devices_.
+* At the _Device Manager_ window, click the _Load_ button and enter the module name: _OpenSC PKCS#11 Module_.<!--Where is the module name listed in OpenSC downloads? Is the module the same thing as the driver? (We seem to use "driver" in other places)? Don't see that name in OpenSC download list. No space before "#11"?-->
+* Select the location of the OpenSC PKCS #11 driver based on OS. The default locations include:
 
-| OS | Default driver location | File name | 
+| **OS** | **Default Driver Location** | **Driver File Name** | 
 | ----- | -------| -------| 
-| Windows | C:\Windows\System32 | pkcs11.dll | 
-| MacOS  | /Library/OpenSC/lib/ | pkcs11.so | 
-| Linux  | /usr/lib/ | pkcs11.so | 
+| _Windows_ | C:\Windows\System32 | pkcs11.dll | 
+| _macOS_  | /Library/OpenSC/lib/ | pkcs11.so | 
+| _Linux_  | /usr/lib/ | pkcs11.so | 
 
-* Click _Open_ and verify that the module has been loaded. Then, click _OK_ to return to the _Privacy & Security_ options.
+* Click _Open_ and verify that the module has been loaded<!--installed?-->. Then, click _OK_ to return to the _Privacy & Security_ options.
 
 ### Import PIV Issuer Certificate
 * Click the _View Certificates_ button. If prompted, enter your PIV credential PIN.

--- a/_engineering/01_firefox.md
+++ b/_engineering/01_firefox.md
@@ -53,7 +53,6 @@ Launch **_Firefox_** and load a new _Security Device_ (i.e., the Security Device
 * Click the _Import_ button to import a copy of your PIV credential issuer's Certification Authority (CA) certificate. When prompted, trust the certificate for identifying websites _and_ email users.
 * Click _OK_ and restart _Firefox_.
 
-### Restart Firefox and Test Authentication
-* Restart Firefox. 
+### Test Authentication
 * Browse to a web application that requires authentication with a PIV credential.  A common web application to use as a test is [MAX.gov](https://max.gov/maxportal/home.action){:target="_blank"}. (**Note:** You'll need to have an existing MAX.gov account for this to work.)
 * Firefox will prompt you to enter your PIV credential PIN and select a certificate for authentication.

--- a/_engineering/01_firefox.md
+++ b/_engineering/01_firefox.md
@@ -31,13 +31,14 @@ You need to consider some items that are specific for the US Government.
 * You can push the packages to the enterprise workstations using your enterprise configuration management tools.
 
 ## Configure Firefox
+Perform the steps below to configure Firefox to enable PIV authentication.
 
-Next, you have to configure Firefox to recognize the OpenSC drivers.  
+### Load New Security Device
 
-Launch **_Firefox_** and configure the driver:
-
-* From the _Firefox_ taskbar, click the _Options_ icon ("wheel" shape). 
-* Click the _Advanced_ tab **>**&nbsp;_Certificates **>** Security Devices_.
+Launch **_Firefox_** and load a new security device using the OpenSC PKCS #11 driver:
+* From the _Firefox_ taskbar, click the _Options_ icon ("gear" shape). 
+* Click the _Privacy & Security_ menu from the left-hand navigation.
+* Scroll down until you see the _Certificates_ heading, then click _Security Devices_.
 * At the _Device Manager_ window, click the _Load_ button and enter the certificate name: _OpenSC PKCS#11 Module_.
 * Based on the OS, select the location of the pkcs11 driver.  The default locations include:
 
@@ -47,8 +48,14 @@ Launch **_Firefox_** and configure the driver:
 | MacOS  | /Library/OpenSC/lib/ | pkcs11.so | 
 | Linux  | /usr/lib/ | pkcs11.so | 
 
+* Click _Open_ and verify that the module has been loaded. Then, click _OK_ to return to the _Privacy & Security_ options.
 
-* Click _Open_ and verify that the module has been loaded. 
-* Click _OK_ and restart _Firefox_. 
-* Next, browse to a web application that requires a PIV to authenticate.  A common web application to use is **Max.gov**.
-* Firefox will prompt you to select the PIV certificate
+### Import PIV Issuer Certificate
+* Click the _View Certificates_ button. If prompted, enter your PIV credential PIN.
+* Click the _Authorities_ tab from the top navigation.
+* Click the _Import_ button to import a copy of your PIV credential issuer's certification authority certificate. Trust the certificate for _both_ identifying websites and email users.
+* Click _OK_ and restart _Firefox_.
+
+### Restart and Test Authentication
+* Browse to a web application that requires a PIV to authenticate.  A common web application to use is **Max.gov**.
+* Firefox will prompt you to enter your PIV credential PIN and select a certificate for authentication.


### PR DESCRIPTION
@lachellel @djpackham 

Please find a pull request to address Issue #204. An email also came into icam@gsa.gov last night regarding the same issue.

We've updated the instructions to highlight the need to import the issuing CA's certificate into the Firefox trust store. @clstmbrly also did a plain-language review/scrub.

LP: https://federalist-proxy.app.cloud.gov/preview/gsa/piv-guides/204-firefox-update/engineering/firefox/#configure-firefox

Please let me know if there are any questions.

- Ryan