### PR TITLE
Federal Common Policy CA G2 Update

### DIFF
--- a/_networkconfig/01_portsprotocols.md
+++ b/_networkconfig/01_portsprotocols.md
@@ -5,7 +5,7 @@ collection: networkconfig
 permalink: networkconfig/ports/
 ---
 
-Your workstations, servers, network domain controllers and applications need to validate the [revocation]({{site.baseurl}}/pivcertchains#revocation) status of the PIV certificates and all intermediate certificate authority certificates.  In addition, the [certificate chain]({{site.baseurl}}/pivcertchains#certificate-chains) path building may retrieve and download the intermediate certificate authority certificates.
+Your workstations, servers, network domain controllers and applications need to validate the [revocation]({{site.baseurl}}/pivcertchains#revocation) status of the PIV certificates and all intermediate certification authority certificates.  In addition, the [certificate chain]({{site.baseurl}}/pivcertchains#certificate-chains) path building may retrieve and download the intermediate certification authority certificates.
 
 The validation occurs in real-time (with some caching) and requires ensuring network traffic is open and available to the destination web services, ports, and protocols.  Many US Federal agencies implement a layered network security model with demilitarized zones (DMZs), proxies and Trusted Internet Connections (TICs) to monitor, defend and protect the networks, applications and users.
 
@@ -53,8 +53,8 @@ The graphical user interface allows you to check OCSP, CRL, and AIA (intermediat
 
 | Type | Certificate Extension | Protocol (Port) | Considerations|
 | ----- | -------| -------| ------|
-| OCSP | Authority Information Access | HTTP (80) | All PIV certificates have OCSP references and OCSP URLs which are internet accessible and provided by the issuing certificate authority. Intermediate certificate authorities are **not** required to have OCSP available for the _intermediate_ certificates.|
-| CRL  | CRL Distribution Point (CDP) | HTTP (80) | All PIV certificates have CRL capabilities provided by the issuing certificate authority.  All intermediate certificate authority certificates have CRL capabilities.  CRL files have an expiration time which varies between 6 hours to 18 hours. CRL file sizes range from a few kilobytes to over 30 megabytes (MB).
+| OCSP | Authority Information Access | HTTP (80) | All PIV certificates have OCSP references and OCSP URLs which are internet accessible and provided by the issuing certification authority. Intermediate certification authorities are **not** required to have OCSP available for the _intermediate_ certificates.|
+| CRL  | CRL Distribution Point (CDP) | HTTP (80) | All PIV certificates have CRL capabilities provided by the issuing certification authority.  All intermediate certification authority certificates have CRL capabilities.  CRL files have an expiration time which varies between 6 hours to 18 hours. CRL file sizes range from a few kilobytes to over 30 megabytes (MB).
 
 Lightweight Directory Application Protocol (LDAP) for retrieving information is not preferred and has been increasingly deprecated therefore LDAP is not included.
 
@@ -62,8 +62,8 @@ There are dozens of OCSP and CRL URLs for *all* issued PIV credentials.  If you 
 
 ## Web services for the Federal Public Key Infrastructure
 
-The Federal Common Policy Certificate Authority (COMMON) is the root certificate authority and has web services to publish both [certificate chains]({{site.baseurl}}/pivcertchains#certificate-chains) (p7b files) and [CRLs](../../pivcertchains#revocation) for all intermediate certificate authorities which the root signs.
+The Federal Common Policy Certification Authority (COMMON) is the root certification authority and has web services to publish both [certificate chains]({{site.baseurl}}/pivcertchains#certificate-chains) (p7b files) and [CRLs](../../pivcertchains#revocation) for all intermediate certification authorities which the root signs.
 
-To enable communications with these Federal Common Policy Certificate Authority services, including those currently operational and any expansion, you should verify outbound communications to the base domain of http.fpki.gov. For example, a successful connection to http://http.fpki.gov/fcpca/fcpca.crt will download a copy of the Federal Common Policy CA certificate.
+To enable communications with these Federal Common Policy Certification Authority services, including those currently operational and any expansion, you should verify outbound communications to the base domain of http.fpki.gov. For example, a successful connection to http://http.fpki.gov/fcpca/fcpca.crt will download a copy of the Federal Common Policy CA certificate.
 
 You should consider allowing two protocols (port): HTTP (80) and DNS (53).  Although the web services for publishing CRLs are not currently served over HTTPS (443), you may want to allow HTTPS (443) to future proof for any expansion.

--- a/_networkconfig/02_domaincontrollers.md
+++ b/_networkconfig/02_domaincontrollers.md
@@ -44,9 +44,9 @@ Domain Controller certificates must be issued with a set of specific extensions 
 
 ## Issue Domain Controller certificates
 
-US Federal Civilian agencies have a variety of information security policies.  These policies cover whether you should use a Domain Controller certificate issued from your agency's local enterprise Certificate Authority, or whether the certificate must be issued from a Certificate Authority managed and certified under the Federal Public Key Infrastructure (FPKI).  Each agency's information security policy should be followed.
+US Federal Civilian agencies have a variety of information security policies.  These policies cover whether you should use a Domain Controller certificate issued from your agency's local enterprise certification authority, or whether the certificate must be issued from a certification authority managed and certified under the Federal Public Key Infrastructure (FPKI).  Each agency's information security policy should be followed.
 
-It is not recommended to set up a local enterprise certificate authority just to issue domain controller certificates without ensuring the proper management and security protections are enabled.  Your Chief Information Security Officer (CISO) must have awareness and oversight established for the certificate authority management.
+It is not recommended to set up a local enterprise certification authority just to issue domain controller certificates without ensuring the proper management and security protections are enabled.  Your Chief Information Security Officer (CISO) must have awareness and oversight established for the certification authority management.
 
 Collaborate with your Chief Information Security Officer (CISO) or Information Security office for a definitive answer and direction.
 

--- a/pages/certchains.md
+++ b/pages/certchains.md
@@ -16,27 +16,27 @@ If you are looking for the root certificates, you can quickly jump to the end of
 
 
 ## Trust
-Identity certificates are issued and digitally signed by a _Certificate Authority_.  The _Certificate Authority_ that signed your PIV certificates is called an _**Intermediate** Certificate Authority_ because it was issued a certificate by another _Certificate Authority_.  This process of issuing and signing continues until there is one  _Certificate Authority_ that is called the _**Root** Certificate Authority_.
+Identity certificates are issued and digitally signed by a _Certification Authority_.  The _Certification Authority_ that signed your PIV certificates is called an _**Intermediate** Certification Authority_ because it was issued a certificate by another _Certification Authority_.  This process of issuing and signing continues until there is one  _Certification Authority_ that is called the _**Root** Certification Authority_.
 
-The full process of proving identity when issuing the certificates, auditing the certificate authorities, and the cryptographic protections of the digital signatures establish the basis of Trust for PIV credentials and certificates.
+The full process of proving identity when issuing the certificates, auditing the certification authorities, and the cryptographic protections of the digital signatures establish the basis of Trust for PIV credentials and certificates.
 
 ![Example of an identity certificate with intermediate and root]({{site.baseurl}}/img/certificatechain_small.png){:style="float:center"}
 
-For the US Federal Government Executive branch agencies, there is one Root Certificate Authority named _Federal Common Policy Certificate Authority (COMMON)_, and dozens of Intermediate Certificate Authorities.  The US Federal Government has also established Trust with other Certificate Authorities which serve business communities, State and Local government communities, and international government communities.
+For the US Federal Government Executive branch agencies, there is one Root Certification Authority named _Federal Common Policy Certification Authority (COMMON)_, and dozens of Intermediate Certification Authorities.  The US Federal Government has also established Trust with other Certification Authorities which serve business communities, State and Local government communities, and international government communities.
 
 * [CLICK HERE: A graph of the federal public key infrastructure, including the business communities](https://fpki.idmanagement.gov/tools/fpkigraph/){:target="_blank"}
 
-The participating Certificate Authorities and the policies, processes, and auditing is referred to as the [*Federal Public Key Infrastructure (FPKI)*](https://www.idmanagement.gov/IDM/s/article_content_old?tag=a0Gt0000000SfwP){:target="_blank"}
+The participating Certification Authorities and the policies, processes, and auditing is referred to as the [*Federal Public Key Infrastructure (FPKI)*](https://www.idmanagement.gov/IDM/s/article_content_old?tag=a0Gt0000000SfwP){:target="_blank"}
 
 ## Certificate Chains
 To digitally trust YOU and your PIV credential certificates, the workstations, servers, applications and network domains will be configured. Understanding and managing certificate chains are one of the methods to configure trust.
 
-The certificate chain includes the Intermediate Certificate Authorities certificates and the Federal Common Policy Certificate Authority (COMMON) root certificate.
+The certificate chain includes Intermediate Certification Authority certificates and the Federal Common Policy Certification Authority (COMMON) root certificate.
 
 ![Example of a PIV certificate chain to Common]({{site.baseurl}}/img/pivcertificatechain_small.png){:style="float:center"}
 
 
-{% include alert-info.html heading = "Federal PKI Person Root - COMMON" content="The Federal Common Policy Certificate Authority (COMMON) root certificate is included in Microsoft, Adobe and some Apple trust stores by default.  It is not included by default in Mozilla, java, all mobile device operating systems, or Linux based operating systems." %}
+{% include alert-info.html heading = "Federal PKI Person Root - COMMON" content="The Federal Common Policy Certification Authority (COMMON) root certificate is included in Microsoft, Adobe and some Apple trust stores by default.  It is not included by default in Mozilla, java, all mobile device operating systems, or Linux based operating systems." %}
 
 If you are an engineer working on implementing PIV authentication, you may need to download and install the root certificate (COMMON) for your workstations, servers, applications and network domains.
 
@@ -44,36 +44,43 @@ Many applications may require Intermediate Certificates to successfully trust AL
 
 General recommendations for trust and certificate chain management include:
 
-- COMMON should be used as the trusted root certificate authority
-- Management of root and intermediate certificate authority certificates and distribution to network domains, workstations, servers and applications should be managed with group policy objects, secure automated distributions mechanisms, and enterprise policies and procedures to ensure updates are managed effectively.
+- COMMON should be used as the trusted root certification authority
+- Management of root and intermediate certification authority certificates and distribution to network domains, workstations, servers and applications should be managed with group policy objects, secure automated distributions mechanisms, and enterprise policies and procedures to ensure updates are managed effectively.
 - NIST published an [Information Technology Laboratory (ITL) bulletin](http://csrc.nist.gov/publications/nistbul/july-2012_itl-bulletin.pdf){:target="_blank"} in July 2012 which includes general practices to consider.
 
 Installation of the trusted root certificate and intermediate certificates is dependent upon operating systems and applications. Instructions for [downloading](#download-root-and-intermediate-certificates) are at the end of this page.
 
+{% include alert-info.html content= "Upcoming changes to the Federal Common Policy Certification Authority will impact your agency.  Learn more about this update <a href=\"https://fpki.idmanagement.gov/common/\" target=\"_blank\" rel=\"noreferrer\">here</a>." %}
+
+In <strong>October 2020</strong>, the Federal Government created a new FPKI root certification authority.  The new root is named the <strong>Federal Common Policy CA G2</strong>. Between December 2020 and May 2021, the intermediate certification authorities signed by the old root will be migrated to be signed by this new root: Federal Common Policy CA G2.  Once the migration is complete, the old root will be decommissioned.
+
+{% include alert-info.html content="We are collaborating with CISA on a series of webinars to communicate the upcoming changes and answer your questions.  Email fpkirootupdate@gsa.gov to join our next webinar on <strong>January 28, 2021 at 11 AM ET</strong>." %} 
+
+
 ## Revocation
 Revocation is the process and technology to identify a certificate as no longer valid - to tell computers and applications _"do not trust this certificate anymore"_.
 
-PIV credential certificates will be _revoked_ when a user terminates employment or a contract with an agency, is issued a new credential, is issued an updated PIV credential, or has a lost, stolen or damaged PIV credential.  The revocation of PIV credential certificates occurs with the PIV credential issuer and certificate authority.
+PIV credential certificates will be _revoked_ when a user terminates employment or a contract with an agency, is issued a new credential, is issued an updated PIV credential, or has a lost, stolen or damaged PIV credential.  The revocation of PIV credential certificates occurs with the PIV credential issuer and certification authority.
 
 There are two protocols available to verify if a PIV credential certificate has been revoked:
 
 - Online Certificate Status Protocol (OCSP)
 - Certificate Revocation Lists (CRLs)
 
-Some implementations also validate whether the Intermediate Certificate Authority certificates have been _revoked_.  While a revocation of an Intermediate Certificate Authority certificate does not occur often, this is a safeguard in place and each Intermediate Certificate Authority and COMMON also publishes Certificate Revocation Lists for the certificates signed next in the chain.   
+Some implementations also validate whether the Intermediate Certification Authority certificates have been _revoked_.  While a revocation of an Intermediate Certification Authority certificate does not occur often, this is a safeguard in place and each Intermediate Certification Authority and COMMON also publishes Certificate Revocation Lists for the certificates signed next in the chain.   
 
 The table below outlines general information on each protocol, the certificate extension which contains the reference, and design considerations.
 
 | Type | Certificate Extension | Protocol (Port) | Considerations|
 | ----- | -------| -------| ------|
-| OCSP | Authority Information Access | HTTP (80) | All PIV certificates have OCSP references and OCSP responder web services which are internet accessible and provided by the issuing certificate authority. Intermediate certificate authorities are **not** required to have OCSP available for the _intermediate_ certificates.|
-| CRL  | CRL Distribution Point (CDP) | HTTP (80) | All PIV certificates have CRL references and CRLs files published to internet accessible web services by the issuing certificate authority.  All intermediate certificate authority certificates also have CRL references, files and internet accessible web services.  CRL files have an expiration time which varies between 6 hours to 18 hours. CRL file sizes distributed by issuing certificate authorities as of the date of this guide range from a few kilobytes to **over 30 megabytes (MB)**.
+| OCSP | Authority Information Access | HTTP (80) | All PIV certificates have OCSP references and OCSP responder web services which are internet accessible and provided by the issuing certification authority. Intermediate certification authorities are **not** required to have OCSP available for the _intermediate_ certificates.|
+| CRL  | CRL Distribution Point (CDP) | HTTP (80) | All PIV certificates have CRL references and CRLs files published to internet accessible web services by the issuing certification authority.  All intermediate certification authority certificates also have CRL references, files and internet accessible web services.  CRL files have an expiration time which varies between 6 hours to 18 hours. CRL file sizes distributed by issuing certification authorities as of the date of this guide range from a few kilobytes to **over 30 megabytes (MB)**.
 
 For a portion of your implementations such as network authentication, the _revocation_ checks will occur as part of the operating system or server native functionality.  Other implementations may want to consider services such as implementing Server Certificate Validation Protocol (SCVP).  These are advanced topics to consider and will be covered in other areas of guides soon.  
 
 ## Download root and intermediate certificates
 
-The Federal Common Policy Certificate Authority (COMMON) root certificate can be retrieved via two methods: online or out of band.  We recommend requesting the root certificate using the out of band (email) method for engineers working in production environments.
+The Federal Common Policy Certification Authority (COMMON) and Federal Common Policy CA G2 root certificates can be retrieved via two methods: online or out of band.  We recommend the out of band (email) method for engineers working in production environments.
 
 #### Download root using out-of-band email
 - Send an email to: _fpki-help at gsa dot gov_
@@ -82,11 +89,18 @@ The Federal Common Policy Certificate Authority (COMMON) root certificate can be
 - A signed version of the certificate or email will be sent back to you
 
 #### Download root using online site
+
+##### Federal Common Policy CA
 - http://http.fpki.gov/fcpca/fcpca.crt
 - cn=Federal Common Policy CA, ou=FPKI, o=U.S. Government, c=US
 - SHA1 Hash: 90 5f 94 2f d9 f2 8f 67 9b 37 81 80 fd 4f 84 63 47 f6 45 c1
 
-{% include alert-warning.html heading = "Verify the hash of the files" content="Verify the hash of the fcpca.crt file matches the one listed above before using.  If the hash does not match, do NOT use the certificate file and please use the out-of-band email method." %}
+##### Federal Common Policy CA G2
+- http://repo.fpki.gov/fcpca/fcpcag2.crt
+- cn=Federal Common Policy CA G2, ou=FPKI, o=U.S. Government, c=US
+- SHA1 Hash: 99 B4 25 1E 2E EE 05 D8 29 2E 83 97 A9 01 65 29 3D 11 60 28
+
+{% include alert-warning.html heading = "Verify the hash of the files" content="Verify the hash of the root certificate file matches the entry above before using.  If the hash does not match, do NOT use the certificate file and please use the out-of-band email method." %}
 
 You can verify the hash using common utilities on operating systems, including:
 
@@ -102,14 +116,14 @@ You can verify the hash using common utilities on operating systems, including:
 	sha1sum fcpca.crt
 ```
 
-#### Download any additional Intermediate Certificate Authority certificates
+#### Download any additional Intermediate Certification Authority certificates
 
 You can contact your agency's information security teams for help on additional intermediate certificates, or find the intermediate certificates by using information in your PIV certificates directly.
 
 - View your PIV Authentication certificate. To review how to view your PIV Authentication certificate go to the [Details of a PIV Credential]({{site.baseurl}}/details)
 - In the **Authority Information Access (AIA)** extension, there is a URL (http://) which references a file with a .p7b or .p7c extension
-- Download the file, open it, and view the intermediate certificate authority certificates
-- Repeat the process using the AIA extension of the intermediate certificate authority certificates until the final reference finds an intermediate certificate authority certificate that is issued and signed by COMMON
+- Download the file, open it, and view the intermediate certification authority certificates
+- Repeat the process using the AIA extension of the intermediate certification authority certificates until the final reference finds an intermediate certification authority certificate that is issued and signed by COMMON
 
 Many products and implementations may automatically retrieve the intermediate certificates during a process called _certificate path building_ or _certificate path discovery_.   You will encounter varying implementations of the _certificate path discovery_ process based on differences in client operating systems, browsers, mobile devices, programming languages, and even applications directly. It can be challenging to understand all the options that impact your users and applications and we are seeking input and contributions to expand this information for you.     
 

--- a/pages/certchains.md
+++ b/pages/certchains.md
@@ -26,7 +26,7 @@ For the US Federal Government Executive branch agencies, there is one Root Certi
 
 * [CLICK HERE: A graph of the federal public key infrastructure, including the business communities](https://fpki.idmanagement.gov/tools/fpkigraph/){:target="_blank"}
 
-The participating Certification Authorities and the policies, processes, and auditing is referred to as the [*Federal Public Key Infrastructure (FPKI)*](https://www.idmanagement.gov/IDM/s/article_content_old?tag=a0Gt0000000SfwP){:target="_blank"}
+The participating Certification Authorities and the policies, processes, and auditing is referred to as the [*Federal Public Key Infrastructure (FPKI)*](https://www.idmanagement.gov/topics/fpki/){:target="_blank"}
 
 ## Certificate Chains
 To digitally trust YOU and your PIV credential certificates, the workstations, servers, applications and network domains will be configured. Understanding and managing certificate chains are one of the methods to configure trust.
@@ -36,7 +36,7 @@ The certificate chain includes Intermediate Certification Authority certificates
 ![Example of a PIV certificate chain to Common]({{site.baseurl}}/img/pivcertificatechain_small.png){:style="float:center"}
 
 
-{% include alert-info.html heading = "Federal PKI Person Root - COMMON" content="The Federal Common Policy Certification Authority (COMMON) root certificate is included in Microsoft, Adobe and some Apple trust stores by default.  It is not included by default in Mozilla, java, all mobile device operating systems, or Linux based operating systems." %}
+{% include alert-info.html heading = "Federal PKI Person Root - COMMON" content="The current Federal Common Policy Certification Authority (COMMON) root certificate is included in Microsoft, Adobe and some Apple trust stores by default.  It is not included by default in Mozilla, Java, all mobile device operating systems, or Linux based operating systems." %}
 
 If you are an engineer working on implementing PIV authentication, you may need to download and install the root certificate (COMMON) for your workstations, servers, applications and network domains.
 

--- a/pages/certchains.md
+++ b/pages/certchains.md
@@ -4,7 +4,7 @@ title: Certificate Trust
 permalink: /pivcertchains/
 ---
 
-One of the most common questions is "What are all these certificates and how do I configure my applications to use them?"  Answering this question involves explaining Trust, Certificate chains and Revocation.  
+One of the most common questions is "What are all these certificates and how do I configure my applications to use them?"  Answering this question involves explaining trust, certificate chains and revocation.  
 
 - [Trust](#trust)
 - [Certificate *chains*](#certificate-chains)
@@ -16,22 +16,22 @@ If you are looking for the root certificates, you can quickly jump to the end of
 
 
 ## Trust
-Identity certificates are issued and digitally signed by a _Certification Authority_.  The _Certification Authority_ that signed your PIV certificates is called an _**Intermediate** Certification Authority_ because it was issued a certificate by another _Certification Authority_.  This process of issuing and signing continues until there is one  _Certification Authority_ that is called the _**Root** Certification Authority_.
+Identity certificates are issued and digitally signed by a _certification authority_.  The _certification authority_ that signed your PIV certificates is called an _**intermediate** certification authority_ because it was issued a certificate by another _certification authority_.  This process of issuing and signing continues until there is one  _certification authority_ that is called the _**root** certification authority_.
 
 The full process of proving identity when issuing the certificates, auditing the certification authorities, and the cryptographic protections of the digital signatures establish the basis of Trust for PIV credentials and certificates.
 
 ![Example of an identity certificate with intermediate and root]({{site.baseurl}}/img/certificatechain_small.png){:style="float:center"}
 
-For the US Federal Government Executive branch agencies, there is one Root Certification Authority named _Federal Common Policy Certification Authority (COMMON)_, and dozens of Intermediate Certification Authorities.  The US Federal Government has also established Trust with other Certification Authorities which serve business communities, State and Local government communities, and international government communities.
+For the US Federal Government Executive branch agencies, there is one root certification authority named _Federal Common Policy Certification Authority (COMMON)_, and dozens of intermediate certification Authorities.  The US Federal Government has also established trust with other certification authorities which serve business communities, State and Local government communities, and international government communities.
 
 * [CLICK HERE: A graph of the federal public key infrastructure, including the business communities](https://fpki.idmanagement.gov/tools/fpkigraph/){:target="_blank"}
 
-The participating Certification Authorities and the policies, processes, and auditing is referred to as the [*Federal Public Key Infrastructure (FPKI)*](https://www.idmanagement.gov/topics/fpki/){:target="_blank"}
+The participating certification authorities and the policies, processes, and auditing is referred to as the [*Federal Public Key Infrastructure (FPKI)*](https://www.idmanagement.gov/topics/fpki/){:target="_blank"}
 
 ## Certificate Chains
 To digitally trust YOU and your PIV credential certificates, the workstations, servers, applications and network domains will be configured. Understanding and managing certificate chains are one of the methods to configure trust.
 
-The certificate chain includes Intermediate Certification Authority certificates and the Federal Common Policy Certification Authority (COMMON) root certificate.
+The certificate chain includes intermediate certification authority certificates and the Federal Common Policy Certification Authority (COMMON) root certificate.
 
 ![Example of a PIV certificate chain to Common]({{site.baseurl}}/img/pivcertificatechain_small.png){:style="float:center"}
 
@@ -40,7 +40,7 @@ The certificate chain includes Intermediate Certification Authority certificates
 
 If you are an engineer working on implementing PIV authentication, you may need to download and install the root certificate (COMMON) for your workstations, servers, applications and network domains.
 
-Many applications may require Intermediate Certificates to successfully trust ALL PIV credentials, and may not support the automatic retrieval of certificate chains.  You should consider the possible unintended consequences of installing intermediate certificates which _only_ represent intermediate certificate chains for your agency users.  You may want to be able to Trust all PIV credentials from agencies, and credentials from our trusted partners.  It is increasingly more common for users from other agencies or partners to _authenticate_ to your networks or applications, and this usage is the foundation of PIV to promote trust, interoperability, authentication, and efficiency across the US Federal Government.  
+Many applications may require intermediate certificates to successfully trust ALL PIV credentials, and may not support the automatic retrieval of certificate chains.  You should consider the possible unintended consequences of installing intermediate certificates which _only_ represent intermediate certificate chains for your agency users.  You may want to be able to Trust all PIV credentials from agencies, and credentials from our trusted partners.  It is increasingly more common for users from other agencies or partners to _authenticate_ to your networks or applications, and this usage is the foundation of PIV to promote trust, interoperability, authentication, and efficiency across the US Federal Government.  
 
 General recommendations for trust and certificate chain management include:
 
@@ -67,7 +67,7 @@ There are two protocols available to verify if a PIV credential certificate has 
 - Online Certificate Status Protocol (OCSP)
 - Certificate Revocation Lists (CRLs)
 
-Some implementations also validate whether the Intermediate Certification Authority certificates have been _revoked_.  While a revocation of an Intermediate Certification Authority certificate does not occur often, this is a safeguard in place and each Intermediate Certification Authority and COMMON also publishes Certificate Revocation Lists for the certificates signed next in the chain.   
+Some implementations also validate whether the intermediate certification authority certificates have been _revoked_.  While a revocation of an intermediate certification authority certificate does not occur often, this is a safeguard in place and each intermediate certification Authority and COMMON also publishes Certificate Revocation Lists for the certificates signed next in the chain.   
 
 The table below outlines general information on each protocol, the certificate extension which contains the reference, and design considerations.
 

--- a/pages/elements.md
+++ b/pages/elements.md
@@ -40,4 +40,4 @@ The following electronic elements are for usage by YOU:
 - **Digital Signature**, which is a certificate and key pair allows the YOU to digitally sign a document or email, providing both integrity and non-repudiation.
 - **Encryption**, which is a certificate and key pair and allows YOU to digitally encrypt documents or email with your colleagues in the US Federal Government or with government Partners, providing confidentiality through ensuring that only authorized parties can read the document or email.
 
-The Card Authentication, PIV Authentication, Digital Signature, and Encryption all leverage four separate certificates and key pairs, issued from certificate authorities that are audited and certified by the Federal Public Key Infrastructure (FPKI).
+The Card Authentication, PIV Authentication, Digital Signature, and Encryption all leverage four separate certificates and key pairs, issued from certification authorities that are audited and certified by the Federal Public Key Infrastructure (FPKI).


### PR DESCRIPTION
@idmken - put together some edits to address #278.

The updates:
- replace all instances of "certificate authority" with "certification authority" (standardizes content across the playbook)
- introduce Federal Common Policy CA G2 and references FPKI-Guides to learn about the upcoming migration
- add Federal Common Policy CA G2 download instructions
- standardize capitalization of key terms (e.g., "root" and "intermediate") across content sections

Additional edits will be needed once the migration to the Federal Common Policy CA G2 is complete.